### PR TITLE
Version 2.0.0 features and bugfixes

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -7,7 +7,7 @@ output: 'prefixed'
 
 vars:
   PKG_NAME: github.com/glenvan/ttl
-  PKG_VERSION: v1.0.0
+  PKG_VERSION: v2.0.0
 
 tasks:
   default:

--- a/example/example.go
+++ b/example/example.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -9,16 +8,12 @@ import (
 )
 
 func main() {
-	maxTTL := time.Duration(time.Second * 4)        // time in seconds
+	defaultTTL := time.Duration(time.Second * 4)    // time in seconds
 	startSize := 3                                  // initial number of items in map
 	pruneInterval := time.Duration(time.Second * 1) // search for expired items every 'pruneInterval' seconds
-	refreshOnStore := true                          // update item's lastAccessTime on a .Get()
-	t := ttl.NewMap[string, any](
-		context.Background(),
-		maxTTL,
-		startSize,
-		pruneInterval,
-		refreshOnStore)
+	refreshOnLoad := true                           // update item's lastAccessTime on a .Get()
+
+	t := ttl.NewMap[string, any](defaultTTL, startSize, pruneInterval, refreshOnLoad)
 	defer t.Close()
 
 	// populate the ttl.Map
@@ -54,7 +49,7 @@ func main() {
 	}()
 
 	// ttl.Map has an expiration time, wait until this amount of time passes
-	sleepTime := maxTTL + 2*pruneInterval
+	sleepTime := defaultTTL + 2*pruneInterval
 	fmt.Println()
 	fmt.Printf(
 		"Sleeping %v, items should be removed after this time, except for the '%v' key\n",

--- a/example/small/small.go
+++ b/example/small/small.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -9,19 +8,14 @@ import (
 )
 
 func main() {
-	maxTTL := 300 * time.Millisecond        // a key's time to live
+	defaultTTL := 300 * time.Millisecond    // a key's time to live
 	startSize := 3                          // initial number of items in map
 	pruneInterval := 100 * time.Millisecond // prune expired items each time pruneInterval elapses
-	refreshOnStore := true                  // update item's 'lastAccessTime' on ttl.Map.Load()
+	refreshOnLoad := true                   // update item's 'lastAccessTime' on ttl.Map.Load()
 
 	// Any comparable data type such as int, uint64, pointers and struct types (if all field
 	// types are comparable) can be used as the key type
-	t := ttl.NewMap[string, string](
-		context.Background(),
-		maxTTL,
-		startSize,
-		pruneInterval,
-		refreshOnStore)
+	t := ttl.NewMap[string, string](defaultTTL, startSize, pruneInterval, refreshOnLoad)
 	defer t.Close()
 
 	// Populate the ttl.Map
@@ -38,7 +32,7 @@ func main() {
 		return true
 	})
 
-	sleepTime := maxTTL + pruneInterval
+	sleepTime := defaultTTL + pruneInterval
 	fmt.Printf("Sleeping %s, items should be expired and removed afterward\n", sleepTime)
 
 	time.Sleep(sleepTime)

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,6 @@
 package ttl_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -9,19 +8,14 @@ import (
 )
 
 func ExampleMap() {
-	maxTTL := 300 * time.Millisecond        // a key's time to live
+	defaultTTL := 300 * time.Millisecond    // the default lifetime for a key/value pair
 	startSize := 3                          // initial number of items in map
 	pruneInterval := 100 * time.Millisecond // prune expired items each time pruneInterval elapses
-	refreshLastAccessOnGet := true          // update item's 'lastAccessTime' on ttl.Map.Load()
+	refreshOnLoad := true                   // update item's 'lastAccessTime' on ttl.Map.Load()
 
 	// Any comparable data type such as int, uint64, pointers and struct types (if all field
 	// types are comparable) can be used as the key type
-	t := ttl.NewMap[string, string](
-		context.Background(),
-		maxTTL,
-		startSize,
-		pruneInterval,
-		refreshLastAccessOnGet)
+	t := ttl.NewMap[string, string](defaultTTL, startSize, pruneInterval, refreshOnLoad)
 	defer t.Close()
 
 	// Populate the ttl.Map
@@ -38,7 +32,7 @@ func ExampleMap() {
 		return true
 	})
 
-	sleepTime := maxTTL + pruneInterval
+	sleepTime := defaultTTL + pruneInterval
 	fmt.Printf("Sleeping %s, items should be expired and removed afterward\n", sleepTime)
 
 	time.Sleep(sleepTime)
@@ -60,7 +54,7 @@ func ExampleMap() {
 }
 
 func ExampleMap_Load() {
-	tm := ttl.NewMap[string, string](context.Background(), 30*time.Second, 0, 2*time.Second, true)
+	tm := ttl.NewMap[string, string](30*time.Second, 0, 2*time.Second, true)
 	defer tm.Close()
 
 	tm.Store("hello", "world")
@@ -74,7 +68,7 @@ func ExampleMap_Load() {
 }
 
 func ExampleMap_Range() {
-	tm := ttl.NewMap[string, string](context.Background(), 30*time.Second, 0, 2*time.Second, true)
+	tm := ttl.NewMap[string, string](30*time.Second, 0, 2*time.Second, true)
 	defer tm.Close()
 
 	tm.Store("hello", "world")
@@ -95,6 +89,7 @@ func ExampleMap_Range() {
 		return true // continue
 	})
 
+	// Give the goroutine some time to complete
 	time.Sleep(20 * time.Millisecond)
 
 	fmt.Printf("Length after: %d\n", tm.Length())
@@ -104,7 +99,7 @@ func ExampleMap_Range() {
 }
 
 func ExampleMap_DeleteFunc() {
-	tm := ttl.NewMap[string, int](context.Background(), 30*time.Second, 0, 2*time.Second, true)
+	tm := ttl.NewMap[string, int](30*time.Second, 0, 2*time.Second, true)
 	defer tm.Close()
 
 	tm.Store("zero", 0)


### PR DESCRIPTION
- Make Context optional when creating a Map
  - Map.NewMap does not require a context parameter - Internally it uses context.Background
  - Map.NewMapContext does require a context parameter
    - A little easier on the user
- Add per-key-value-pair TTL
  - Rename Map.NewMap and Map.NewMapContext's maxTTL parameter to defaultTTL - Now just the default - key/value pairs inserted with Map.Store will use this default
  - Add Map.StoreWithTTL
    - Adds a custom TTL to each mapItem
- Fix bug in Store
  - If the item exists, the original value was not overwritten
- Rename "refreshOnStore" variables and params to "refreshOnLoad" which is actually what's going on